### PR TITLE
Add proxy bypass pattern support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The build outputs `dist/ai-proxy-redirector.user.js` – this file is the usersc
 - Click the floating **Open proxy settings** pill (or press **Shift + P**) to reveal the settings panel.
 - Enter the protocol (`http` or `https`), host, and port that point to your running proxy server. The default
   configuration expects `http://localhost:8787`.
+- Add any **Bypass patterns** for hosts that should not be proxied (e.g. `api.internal.local`, `*.trusted.com`, or
+  regular expressions such as `/.gov$/i`). Matching requests will be sent directly without touching the proxy.
 - Close the panel – settings persist automatically via Tampermonkey storage.
 
 ## 5. Verify request redirection

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -40,6 +40,8 @@ The build emits `dist/ai-proxy-redirector.user.js`, which is the Tampermonkey-co
 - Click the floating **Open proxy settings** pill or press **Shift + P** to toggle the settings panel.
 - Provide the proxy protocol (`http` or `https`), host, and port. The userscript immediately persists the
   configuration via `GM_setValue` so it will be reused on future page loads.
+- Use the **Bypass patterns** section to list hostnames, wildcard patterns (e.g. `*.example.com`), or
+  JavaScript-style regular expressions (e.g. `/.internal$/`) that should skip the proxy entirely.
 - The preview string in the panel shows how outgoing requests will be rewritten, e.g.
   `https://proxy.example.com:8787/https://original-target.com/api`.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "vite-vue-starter",
-  "version": "0.0.0",
+  "name": "ai-proxy-redirector",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-vue-starter",
-      "version": "0.0.0",
+      "name": "ai-proxy-redirector",
+      "version": "0.1.0",
       "dependencies": {
         "vue": "^3.5.22"
       },

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, inject, onMounted, ref } from 'vue'
+import { normaliseBypassList } from './bypassPatterns'
 import { DEFAULT_PROXY_SETTINGS, resetProxySettings } from './proxySettings'
 
 const proxySettings = inject('proxySettings')
@@ -11,9 +12,7 @@ const previewDetails = computed(() => {
   const host = proxySettings.host || '<proxy-host>'
   const port = proxySettings.port ? `:${proxySettings.port}` : ':<proxy-port>'
   const sampleUrl = `${protocol}://${host}${port}/https://example.com/path`
-  const bypassList = Array.isArray(proxySettings.bypassList)
-    ? proxySettings.bypassList.filter((entry) => entry && entry.trim())
-    : []
+  const bypassList = normaliseBypassList(proxySettings.bypassList)
 
   let bypassMessage =
     'All requests will be proxied unless they already point at the proxy host.'
@@ -50,20 +49,16 @@ function addBypassPattern() {
   const value = newBypassPattern.value.trim()
   if (!value) return
 
-  const existing = Array.isArray(proxySettings.bypassList)
-    ? proxySettings.bypassList
-    : []
-
-  if (!existing.includes(value)) {
-    proxySettings.bypassList = [...existing, value]
-  }
+  const existing = normaliseBypassList(proxySettings.bypassList)
+  const updated = normaliseBypassList([...existing, value])
+  proxySettings.bypassList = updated
 
   newBypassPattern.value = ''
 }
 
 function removeBypassPattern(index) {
-  if (!Array.isArray(proxySettings.bypassList)) return
-  proxySettings.bypassList = proxySettings.bypassList.filter((_, itemIndex) => itemIndex !== index)
+  const existing = normaliseBypassList(proxySettings.bypassList)
+  proxySettings.bypassList = existing.filter((_, itemIndex) => itemIndex !== index)
 }
 
 onMounted(() => {

--- a/frontend/src/bypassPatterns.js
+++ b/frontend/src/bypassPatterns.js
@@ -1,0 +1,175 @@
+const REGEX_PATTERN = /^\/(.*)\/([a-z]*)$/i
+
+function escapeForRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function toArray(value) {
+  if (Array.isArray(value)) {
+    return value
+  }
+
+  if (value == null) {
+    return []
+  }
+
+  const asString = String(value)
+  if (!asString.trim()) {
+    return []
+  }
+
+  if (/[\n,]/.test(asString)) {
+    return asString
+      .split(/[\n,]/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  }
+
+  return [asString]
+}
+
+export function normaliseBypassList(input) {
+  const entries = toArray(input)
+  const seen = new Set()
+  const result = []
+
+  for (const entry of entries) {
+    const trimmed = typeof entry === 'string' ? entry.trim() : String(entry).trim()
+    if (!trimmed || seen.has(trimmed)) {
+      continue
+    }
+    seen.add(trimmed)
+    result.push(trimmed)
+  }
+
+  return result
+}
+
+function compileRegex(pattern) {
+  const match = pattern.match(REGEX_PATTERN)
+  if (!match) return null
+
+  const [, body, flags] = match
+
+  try {
+    return new RegExp(body, flags)
+  } catch (error) {
+    console.warn('[ai-proxy] Invalid bypass regex pattern skipped', pattern, error)
+    return null
+  }
+}
+
+function compileWildcard(pattern) {
+  const escaped = pattern.split('*').map((segment) => escapeForRegex(segment)).join('.*')
+
+  try {
+    const wildcardRegex = new RegExp(`^${escaped}$`, 'i')
+    return (url) => {
+      try {
+        const parsed = new URL(url)
+        return wildcardRegex.test(parsed.hostname) || wildcardRegex.test(parsed.host)
+      } catch (error) {
+        return false
+      }
+    }
+  } catch (error) {
+    console.warn('[ai-proxy] Invalid wildcard bypass pattern skipped', pattern, error)
+    return null
+  }
+}
+
+function compileHostPath(pattern) {
+  const lowered = pattern.toLowerCase()
+  return (url) => url.toLowerCase().includes(lowered)
+}
+
+function compileHostPort(pattern) {
+  const lowered = pattern.toLowerCase()
+  return (url) => {
+    try {
+      return new URL(url).host.toLowerCase() === lowered
+    } catch (error) {
+      return false
+    }
+  }
+}
+
+function compileHostname(pattern) {
+  const lowered = pattern.toLowerCase()
+  return (url) => {
+    try {
+      const { hostname } = new URL(url)
+      const target = hostname.toLowerCase()
+      return target === lowered || target.endsWith(`.${lowered}`)
+    } catch (error) {
+      return false
+    }
+  }
+}
+
+function compileSchemeUrl(pattern) {
+  const lowered = pattern.toLowerCase()
+  return (url) => url.toLowerCase().startsWith(lowered)
+}
+
+function compilePattern(pattern) {
+  if (!pattern) return null
+  const trimmed = pattern.trim()
+  if (!trimmed) return null
+
+  const regex = compileRegex(trimmed)
+  if (regex) {
+    return (url) => regex.test(url)
+  }
+
+  if (trimmed.includes('://')) {
+    return compileSchemeUrl(trimmed)
+  }
+
+  if (trimmed.includes('*')) {
+    return compileWildcard(trimmed)
+  }
+
+  if (trimmed.includes('/')) {
+    return compileHostPath(trimmed)
+  }
+
+  if (trimmed.includes(':')) {
+    return compileHostPort(trimmed)
+  }
+
+  return compileHostname(trimmed)
+}
+
+export function createBypassMatcher(patterns) {
+  const list = normaliseBypassList(patterns)
+  const compiled = list
+    .map((pattern) => compilePattern(pattern))
+    .filter((fn) => typeof fn === 'function')
+
+  return (url, { proxyBase } = {}) => {
+    if (typeof url !== 'string' || !url) {
+      return false
+    }
+
+    if (proxyBase && url.startsWith(proxyBase)) {
+      return true
+    }
+
+    if (!compiled.length) {
+      return false
+    }
+
+    for (const matcher of compiled) {
+      try {
+        if (matcher(url)) {
+          return true
+        }
+      } catch (error) {
+        console.warn('[ai-proxy] Error while evaluating bypass pattern', error)
+      }
+    }
+
+    return false
+  }
+}

--- a/frontend/src/requestInterceptors.js
+++ b/frontend/src/requestInterceptors.js
@@ -19,8 +19,84 @@ function toAbsoluteUrl(input) {
   }
 }
 
-function shouldBypass(url, proxyBase) {
-  return typeof url === 'string' && proxyBase && url.startsWith(proxyBase)
+function toRegex(pattern) {
+  if (!pattern || pattern[0] !== '/') return null
+  const lastSlash = pattern.lastIndexOf('/')
+  if (lastSlash <= 0) return null
+  const source = pattern.slice(1, lastSlash)
+  const flags = pattern.slice(lastSlash + 1)
+  try {
+    return new RegExp(source, flags)
+  } catch (error) {
+    console.warn('[ai-proxy] Invalid bypass regex pattern skipped', pattern, error)
+    return null
+  }
+}
+
+function escapeForRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function matchesBypassPattern(url, pattern) {
+  if (typeof pattern !== 'string') return false
+  const trimmed = pattern.trim()
+  if (!trimmed) return false
+
+  const regex = toRegex(trimmed)
+  if (regex) {
+    return regex.test(url)
+  }
+
+  let parsed
+  try {
+    parsed = new URL(url)
+  } catch (error) {
+    return false
+  }
+
+  const hostWithPort = parsed.host.toLowerCase()
+  const hostname = parsed.hostname.toLowerCase()
+  const lowerPattern = trimmed.toLowerCase()
+
+  if (lowerPattern.includes('://')) {
+    return url.toLowerCase().startsWith(lowerPattern)
+  }
+
+  if (lowerPattern.includes('*')) {
+    const escapedSegments = lowerPattern.split('*').map((segment) => escapeForRegex(segment))
+    const escaped = escapedSegments.join('.*')
+    try {
+      const wildcardRegex = new RegExp(`^${escaped}$`, 'i')
+      return wildcardRegex.test(parsed.hostname) || wildcardRegex.test(parsed.host)
+    } catch (error) {
+      console.warn('[ai-proxy] Invalid wildcard bypass pattern skipped', pattern, error)
+      return false
+    }
+  }
+
+  if (lowerPattern.includes('/')) {
+    return url.toLowerCase().includes(lowerPattern)
+  }
+
+  if (lowerPattern.includes(':')) {
+    return hostWithPort === lowerPattern
+  }
+
+  return hostname === lowerPattern || hostname.endsWith(`.${lowerPattern}`)
+}
+
+function shouldBypass(url, proxyBase, bypassList) {
+  if (typeof url !== 'string') return false
+
+  if (proxyBase && url.startsWith(proxyBase)) {
+    return true
+  }
+
+  if (!Array.isArray(bypassList) || bypassList.length === 0) {
+    return false
+  }
+
+  return bypassList.some((pattern) => matchesBypassPattern(url, pattern))
 }
 
 function rewriteUrl(url, settings) {
@@ -28,7 +104,9 @@ function rewriteUrl(url, settings) {
   if (!proxyBase) return url
 
   const absoluteUrl = toAbsoluteUrl(url)
-  if (shouldBypass(absoluteUrl, proxyBase)) {
+  const bypassList = Array.isArray(settings?.bypassList) ? settings.bypassList : []
+
+  if (shouldBypass(absoluteUrl, proxyBase, bypassList)) {
     return absoluteUrl
   }
 

--- a/frontend/src/requestInterceptors.js
+++ b/frontend/src/requestInterceptors.js
@@ -1,3 +1,5 @@
+import { createBypassMatcher } from './bypassPatterns'
+
 const FETCH_SYMBOL = Symbol('ai-proxy:original-fetch')
 const XHR_OPEN_SYMBOL = Symbol('ai-proxy:original-xhr-open')
 
@@ -19,94 +21,14 @@ function toAbsoluteUrl(input) {
   }
 }
 
-function toRegex(pattern) {
-  if (!pattern || pattern[0] !== '/') return null
-  const lastSlash = pattern.lastIndexOf('/')
-  if (lastSlash <= 0) return null
-  const source = pattern.slice(1, lastSlash)
-  const flags = pattern.slice(lastSlash + 1)
-  try {
-    return new RegExp(source, flags)
-  } catch (error) {
-    console.warn('[ai-proxy] Invalid bypass regex pattern skipped', pattern, error)
-    return null
-  }
-}
-
-function escapeForRegex(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
-function matchesBypassPattern(url, pattern) {
-  if (typeof pattern !== 'string') return false
-  const trimmed = pattern.trim()
-  if (!trimmed) return false
-
-  const regex = toRegex(trimmed)
-  if (regex) {
-    return regex.test(url)
-  }
-
-  let parsed
-  try {
-    parsed = new URL(url)
-  } catch (error) {
-    return false
-  }
-
-  const hostWithPort = parsed.host.toLowerCase()
-  const hostname = parsed.hostname.toLowerCase()
-  const lowerPattern = trimmed.toLowerCase()
-
-  if (lowerPattern.includes('://')) {
-    return url.toLowerCase().startsWith(lowerPattern)
-  }
-
-  if (lowerPattern.includes('*')) {
-    const escapedSegments = lowerPattern.split('*').map((segment) => escapeForRegex(segment))
-    const escaped = escapedSegments.join('.*')
-    try {
-      const wildcardRegex = new RegExp(`^${escaped}$`, 'i')
-      return wildcardRegex.test(parsed.hostname) || wildcardRegex.test(parsed.host)
-    } catch (error) {
-      console.warn('[ai-proxy] Invalid wildcard bypass pattern skipped', pattern, error)
-      return false
-    }
-  }
-
-  if (lowerPattern.includes('/')) {
-    return url.toLowerCase().includes(lowerPattern)
-  }
-
-  if (lowerPattern.includes(':')) {
-    return hostWithPort === lowerPattern
-  }
-
-  return hostname === lowerPattern || hostname.endsWith(`.${lowerPattern}`)
-}
-
-function shouldBypass(url, proxyBase, bypassList) {
-  if (typeof url !== 'string') return false
-
-  if (proxyBase && url.startsWith(proxyBase)) {
-    return true
-  }
-
-  if (!Array.isArray(bypassList) || bypassList.length === 0) {
-    return false
-  }
-
-  return bypassList.some((pattern) => matchesBypassPattern(url, pattern))
-}
-
 function rewriteUrl(url, settings) {
   const proxyBase = buildProxyBase(settings)
   if (!proxyBase) return url
 
   const absoluteUrl = toAbsoluteUrl(url)
-  const bypassList = Array.isArray(settings?.bypassList) ? settings.bypassList : []
+  const bypassMatcher = createBypassMatcher(settings?.bypassList)
 
-  if (shouldBypass(absoluteUrl, proxyBase, bypassList)) {
+  if (bypassMatcher(absoluteUrl, { proxyBase })) {
     return absoluteUrl
   }
 


### PR DESCRIPTION
## Summary
- persist a configurable list of bypass patterns alongside proxy protocol, host, and port
- expose UI controls to add or remove bypass entries and update the live preview messaging
- skip rewriting requests that match configured bypass patterns and document the new option

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4b50bead483208ecf25f310ba43e4