### PR TITLE
Add bypass pattern handling to proxy settings

### DIFF
--- a/frontend/src/proxySettings.js
+++ b/frontend/src/proxySettings.js
@@ -6,6 +6,7 @@ export const DEFAULT_PROXY_SETTINGS = Object.freeze({
   protocol: 'http',
   host: 'localhost',
   port: '8787',
+  bypassPatterns: [],
 })
 
 function getStorageValue() {
@@ -34,18 +35,29 @@ function setStorageValue(value) {
 
 function parseSettings(rawValue) {
   if (!rawValue) {
-    return { ...DEFAULT_PROXY_SETTINGS }
+    return {
+      ...DEFAULT_PROXY_SETTINGS,
+      bypassPatterns: [...DEFAULT_PROXY_SETTINGS.bypassPatterns],
+    }
   }
 
   try {
     const parsed = typeof rawValue === 'string' ? JSON.parse(rawValue) : rawValue
+    const bypassPatterns = Array.isArray(parsed?.bypassPatterns)
+      ? parsed.bypassPatterns
+      : DEFAULT_PROXY_SETTINGS.bypassPatterns
+
     return {
       ...DEFAULT_PROXY_SETTINGS,
       ...parsed,
+      bypassPatterns: normaliseBypassPatterns(bypassPatterns),
     }
   } catch (error) {
     console.warn('[ai-proxy] Unable to parse stored settings, falling back to defaults', error)
-    return { ...DEFAULT_PROXY_SETTINGS }
+    return {
+      ...DEFAULT_PROXY_SETTINGS,
+      bypassPatterns: [...DEFAULT_PROXY_SETTINGS.bypassPatterns],
+    }
   }
 }
 
@@ -66,20 +78,42 @@ function normalisePort(port) {
   return asString.replace(/[^0-9]/g, '')
 }
 
+function normaliseBypassPatterns(patterns) {
+  if (!Array.isArray(patterns)) return []
+
+  const seen = new Set()
+  const result = []
+
+  for (const pattern of patterns) {
+    if (typeof pattern !== 'string') continue
+    const trimmed = pattern.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    result.push(trimmed)
+  }
+
+  return result
+}
+
 let state
 
 export function useProxySettings() {
   if (!state) {
     const initial = parseSettings(getStorageValue())
-    state = reactive({ ...initial })
+    state = reactive({
+      ...initial,
+      bypassPatterns: [...initial.bypassPatterns],
+    })
 
     watch(
       state,
       (value) => {
+        const bypassPatterns = normaliseBypassPatterns(value.bypassPatterns)
         const serialised = JSON.stringify({
           protocol: normaliseProtocol(value.protocol),
           host: normaliseHost(value.host),
           port: normalisePort(value.port),
+          bypassPatterns,
         })
         setStorageValue(serialised)
       },
@@ -96,16 +130,21 @@ export function getProxySettingsSnapshot() {
     protocol: normaliseProtocol(current.protocol),
     host: normaliseHost(current.host),
     port: normalisePort(current.port),
+    bypassPatterns: normaliseBypassPatterns(current.bypassPatterns),
   }
 }
 
 export function resetProxySettings() {
   if (!state) {
-    state = reactive({ ...DEFAULT_PROXY_SETTINGS })
+    state = reactive({
+      ...DEFAULT_PROXY_SETTINGS,
+      bypassPatterns: [...DEFAULT_PROXY_SETTINGS.bypassPatterns],
+    })
     return state
   }
   state.protocol = DEFAULT_PROXY_SETTINGS.protocol
   state.host = DEFAULT_PROXY_SETTINGS.host
   state.port = DEFAULT_PROXY_SETTINGS.port
+  state.bypassPatterns = [...DEFAULT_PROXY_SETTINGS.bypassPatterns]
   return state
 }


### PR DESCRIPTION
## Summary
- add bypass pattern defaults to proxy settings and validate parsed values
- normalise bypass pattern arrays before persisting and when generating snapshots
- reset bypass patterns alongside other proxy fields

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4c355587c832098d036b64c2ec945