### PR TITLE
docs: document proxy bypass configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ The build outputs `dist/ai-proxy-redirector.user.js` – this file is the usersc
 - Enter the protocol (`http` or `https`), host, and port that point to your running proxy server. The default
   configuration expects `http://localhost:8787`.
 - Close the panel – settings persist automatically via Tampermonkey storage.
+- 在同一面板中可以维护「绕过列表」，用于标记不应通过代理重写的请求。例如可输入域名片段
+  （如 `internal.service`）、通配符模式（如 `*.internal`）或使用 `/pattern/flags` 形式的正则表达式
+  （如 `^https://api.example.com$`）。每行代表一条规则，可通过 **添加** 按钮或按下回车将输入保存，
+  点击规则旁的删除图标即可移除。
+- 绕过列表适合保留局域网接口、健康检查或已经通过其他手段保护的服务直连。被匹配到的请求将
+  原样发送，不再经过代理，方便逐步迁移或排查问题。
 
 ## 5. Verify request redirection
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -50,6 +50,11 @@ The build emits `dist/ai-proxy-redirector.user.js`, which is the Tampermonkey-co
   configuration via `GM_setValue` so it will be reused on future page loads.
 - The preview string in the panel shows how outgoing requests will be rewritten, e.g.
   `https://proxy.example.com:8787/https://original-target.com/api`.
+- 在同一面板内可以维护「绕过匹配规则」，用于将特定请求排除在代理之外。支持输入普通字符串
+  （如 `internal.service`）、通配符模式（如 `*.internal`）或 `/pattern/flags` 形式的正则表达式（如
+  `^https://api.example.com$`）。每条规则占一行，可通过 **添加** 按钮或回车保存，点选对应的删除按钮
+  即可移除。被匹配到的请求会直接发往原目标。
+- 预览字符串会在末尾追加绕过规则的摘要，帮助你确认哪些主机或路径会被保留为直连。
 
 You can reset to the default (`http://localhost:8787`) at any time via the **Reset to defaults** button in the
 panel.


### PR DESCRIPTION
## Summary
- describe how to use the bypass list when configuring the proxy endpoint and include typical pattern examples in the root README
- sync the frontend README with bypass list instructions and note how the preview reflects skipped hosts

## Testing
- not run (docs change only)


------
https://chatgpt.com/codex/tasks/task_e_68e4d0323804832094b39c5fbdb787c4