### PR TITLE
添加前后端 CI 流水线

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - "release/**"
+  pull_request:
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test
+
+      - name: Build userscript bundle
+        run: npm run build
+
+      - name: Upload build artifacts
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+
+  server:
+    name: Server
+    runs-on: ubuntu-latest
+    needs: frontend
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Smoke test startup
+        env:
+          HOST: 127.0.0.1
+          PORT: 8787
+        run: |
+          npm start &
+          SERVER_PID=$!
+          trap "kill $SERVER_PID" EXIT
+          READY=false
+          for i in {1..10}; do
+            RESPONSE=$(curl -s http://127.0.0.1:8787/ || true)
+            if echo "$RESPONSE" | grep -q "Invalid proxy request"; then
+              READY=true
+              break
+            fi
+            sleep 1
+          done
+          if [ "$READY" != "true" ]; then
+            echo "Server did not respond as expected" >&2
+            exit 1
+          fi
+          kill $SERVER_PID
+          trap - EXIT

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # AI Proxy Tampermonkey Setup
 
+[![CI](https://github.com/OWNER/ai-proxy/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/ai-proxy/actions/workflows/ci.yml)
+
+> 在正式发布前请将上方徽章中的 `OWNER` 更新为实际的 GitHub 组织或用户名；提交代码前务必确保本地测试通过，以维持持续集成流水线处于绿色状态。
+
 This repository contains two coordinated pieces:
 
 - `frontend/` – a Vue-powered Tampermonkey userscript that rewrites every outbound `fetch`/`XMLHttpRequest` call so


### PR DESCRIPTION
## Summary
- 新建 GitHub Actions 工作流，在 Node.js 18 环境下分别对前端与后端执行依赖安装、测试与构建
- 使用 npm 缓存并上传前端构建产物，方便审阅或复用
- 在项目 README 中补充 CI 徽章与保持流水线绿色的提醒

## Testing
- Not run (CI only change)


------
https://chatgpt.com/codex/tasks/task_e_68e4f902baf48320be9794176bc37ba1