### PR TITLE
Update CI workflow to run server and frontend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,48 +3,36 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  frontend:
+    name: Frontend
     runs-on: ubuntu-latest
-
+    defaults:
+      run:
+        working-directory: frontend
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20.19.x'
-          cache: 'npm'
-          cache-dependency-path: |
-            server/package-lock.json
-            frontend/package-lock.json
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
 
-      - name: Install dependencies (server)
-        working-directory: server
+      - name: Install dependencies
         run: npm ci
 
-      - name: Install dependencies (frontend)
-        working-directory: frontend
-        run: npm ci
-
-      - name: Run tests (server)
-        working-directory: server
+      - name: Run unit tests
         run: npm test
 
-      - name: Run tests (frontend)
-        working-directory: frontend
-        run: npm test
-
-      - name: Build frontend
-        working-directory: frontend
+      - name: Build frontend bundle
         run: npm run build
 
       - name: Install Playwright browsers
-        working-directory: frontend
         run: npx playwright install --with-deps
 
       - name: Run Playwright end-to-end tests
-        working-directory: frontend
         env:
           PLAYWRIGHT_HTML_REPORT: playwright-report
         run: npm run test:e2e
@@ -56,3 +44,51 @@ jobs:
           name: playwright-report
           path: frontend/playwright-report
           if-no-files-found: warn
+
+  server:
+    name: Server
+    runs-on: ubuntu-latest
+    needs: frontend
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.x'
+          cache: npm
+          cache-dependency-path: server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Smoke test startup
+        env:
+          HOST: 127.0.0.1
+          PORT: 8787
+        run: |
+          npm start &
+          SERVER_PID=$!
+          trap "kill $SERVER_PID" EXIT
+          READY=false
+          for i in {1..10}; do
+            RESPONSE=$(curl -s http://127.0.0.1:8787/ || true)
+            if echo "$RESPONSE" | grep -q "Invalid proxy request"; then
+              READY=true
+              break
+            fi
+            sleep 1
+          done
+          if [ "$READY" != "true" ]; then
+            echo "Server did not respond as expected" >&2
+            exit 1
+          fi
+          kill $SERVER_PID
+          trap - EXIT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,91 +1,58 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - main
-      - master
-      - "release/**"
-  pull_request:
+on: [push, pull_request]
 
 jobs:
-  frontend:
-    name: Frontend
+  build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
+
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.19.0
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          node-version: '20.19.x'
+          cache: 'npm'
+          cache-dependency-path: |
+            server/package-lock.json
+            frontend/package-lock.json
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run unit tests
-        run: npm run test
-
-      - name: Build userscript bundle
-        run: npm run build
-
-      - name: Upload build artifacts
-        if: success()
-        uses: actions/upload-artifact@v4
-        with:
-          name: frontend-dist
-          path: frontend/dist
-
-  server:
-    name: Server
-    runs-on: ubuntu-latest
-    needs: frontend
-    defaults:
-      run:
+      - name: Install dependencies (server)
         working-directory: server
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.19.0
-          cache: npm
-          cache-dependency-path: server/package-lock.json
-
-      - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
+      - name: Install dependencies (frontend)
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run tests (server)
+        working-directory: server
         run: npm test
 
-      - name: Smoke test startup
+      - name: Run tests (frontend)
+        working-directory: frontend
+        run: npm test
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright end-to-end tests
+        working-directory: frontend
         env:
-          HOST: 127.0.0.1
-          PORT: 8787
-        run: |
-          npm start &
-          SERVER_PID=$!
-          trap "kill $SERVER_PID" EXIT
-          READY=false
-          for i in {1..10}; do
-            RESPONSE=$(curl -s http://127.0.0.1:8787/ || true)
-            if echo "$RESPONSE" | grep -q "Invalid proxy request"; then
-              READY=true
-              break
-            fi
-            sleep 1
-          done
-          if [ "$READY" != "true" ]; then
-            echo "Server did not respond as expected" >&2
-            exit 1
-          fi
-          kill $SERVER_PID
-          trap - EXIT
+          PLAYWRIGHT_HTML_REPORT: playwright-report
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- update the CI workflow to run on push and pull request events
- install dependencies for both server and frontend and execute their test suites and build
- run Playwright end-to-end tests after installing browsers and upload the report artifact

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e50e476a648320a5d70f8e887afa67