### PR TITLE
Add Tampermonkey menu command to open proxy settings panel

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { computed, inject, onMounted, ref } from 'vue'
+import { computed, inject, onBeforeUnmount, onMounted, ref } from 'vue'
 import { DEFAULT_PROXY_SETTINGS, resetProxySettings } from './proxySettings'
+import { OPEN_SETTINGS_EVENT } from './events'
 
 const proxySettings = inject('proxySettings')
 const panelOpen = ref(false)
@@ -86,13 +87,27 @@ function removeBypassPattern(index) {
   proxySettings.bypassPatterns = normaliseBypassPatterns(next)
 }
 
+function handleKeydown(event) {
+  if (event.key?.toLowerCase() === 'p' && event.shiftKey) {
+    event.preventDefault()
+    togglePanel()
+  }
+}
+
+function handleOpenSettings() {
+  if (!panelOpen.value) {
+    togglePanel()
+  }
+}
+
 onMounted(() => {
-  window.addEventListener('keydown', (event) => {
-    if (event.key?.toLowerCase() === 'p' && event.shiftKey) {
-      event.preventDefault()
-      togglePanel()
-    }
-  })
+  window.addEventListener('keydown', handleKeydown)
+  window.addEventListener(OPEN_SETTINGS_EVENT, handleOpenSettings)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', handleKeydown)
+  window.removeEventListener(OPEN_SETTINGS_EVENT, handleOpenSettings)
 })
 </script>
 

--- a/frontend/src/events.js
+++ b/frontend/src/events.js
@@ -1,0 +1,1 @@
+export const OPEN_SETTINGS_EVENT = 'ai-proxy-open-settings'

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,12 +3,19 @@ import App from './App.vue'
 import './style.css'
 import { getProxySettingsSnapshot, useProxySettings } from './proxySettings'
 import { installRequestInterceptors } from './requestInterceptors'
+import { OPEN_SETTINGS_EVENT } from './events'
 
 const settings = useProxySettings()
 
 installRequestInterceptors(() => getProxySettingsSnapshot())
 
 const containerId = 'ai-proxy-redirector-root'
+
+if (typeof GM_registerMenuCommand === 'function') {
+  GM_registerMenuCommand('打开代理设置', () => {
+    window.dispatchEvent(new CustomEvent(OPEN_SETTINGS_EVENT))
+  })
+}
 
 function mountApp() {
   let mountPoint = document.getElementById(containerId)

--- a/frontend/tests/menu-open.test.js
+++ b/frontend/tests/menu-open.test.js
@@ -1,0 +1,39 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+describe('userscript menu command', () => {
+  it('opens the settings panel when the menu command is triggered', async () => {
+    document.body.innerHTML = ''
+    vi.resetModules()
+
+    vi.stubGlobal('GM_getValue', vi.fn().mockReturnValue(null))
+    vi.stubGlobal('GM_setValue', vi.fn())
+
+    const registerMenuCommand = vi.fn()
+    vi.stubGlobal('GM_registerMenuCommand', registerMenuCommand)
+
+    try {
+      await import('../src/main.js')
+
+      if (registerMenuCommand.mock.calls.length === 0) {
+        document.dispatchEvent(new Event('DOMContentLoaded'))
+        await nextTick()
+      }
+
+      expect(registerMenuCommand).toHaveBeenCalledTimes(1)
+      const [label, callback] = registerMenuCommand.mock.calls[0]
+      expect(label).toBe('打开代理设置')
+      expect(callback).toBeTypeOf('function')
+
+      callback()
+      await nextTick()
+
+      const panel = document.querySelector('.proxy-panel')
+      expect(panel).not.toBeNull()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -15,7 +15,7 @@ export default defineConfig({
         description:
           'Intercepts fetch/XMLHttpRequest calls and rewrites them to a configurable reverse proxy endpoint.',
         match: ['*://*/*'],
-        grant: ['GM_getValue', 'GM_setValue'],
+        grant: ['GM_getValue', 'GM_setValue', 'GM_registerMenuCommand'],
       },
       build: {
         fileName: 'ai-proxy-redirector.user.js',


### PR DESCRIPTION
## Summary
- grant GM_registerMenuCommand so the userscript can expose a menu action
- dispatch a custom event from the menu callback and listen in App.vue to open the settings panel
- add a Vitest case that asserts the menu command opens the panel

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e54018607483208f5167e0ed758902