### PR TITLE
Add EventSource proxy interception support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository contains two coordinated pieces:
 
-- `frontend/` – a Vue-powered Tampermonkey userscript that rewrites every outbound `fetch`/`XMLHttpRequest` call so
+- `frontend/` – a Vue-powered Tampermonkey userscript that rewrites every outbound `fetch`/`XMLHttpRequest`/`EventSource` call so
   it flows through a configurable proxy endpoint.
 - `server/` – a Node.js reverse proxy that accepts requests at `/protocol://host/...` and forwards them to the
   original destination while preserving method, headers, body, and streaming responses.
@@ -63,7 +63,7 @@ The build outputs `dist/ai-proxy-redirector.user.js` – this file is the usersc
 With the userscript enabled and the proxy server running:
 
 1. Open your browser’s developer tools and switch to the **Network** tab.
-2. Trigger a `fetch` or XHR request on the page (for example, run `fetch('https://httpbin.org/get')` in the console).
+2. Trigger a `fetch`、XHR 或 `EventSource` 请求（例如在控制台运行 `fetch('https://httpbin.org/get')`，或监听一个使用 Server-Sent Events 的页面）。
 3. Observe that the request URL in the network log now points to `http://<proxy-host>:<proxy-port>/<original URL>` and
    that the response arrives successfully via the proxy.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,7 +1,7 @@
 # AI Proxy Redirector Userscript
 
-This package bundles a Vue-powered Tampermonkey userscript that reroutes every `fetch` and `XMLHttpRequest`
-request through a configurable reverse proxy. The UI ships as an overlay panel rendered by Vue and persists
+This package bundles a Vue-powered Tampermonkey userscript that reroutes every `fetch`, `XMLHttpRequest`, and
+`EventSource` request through a configurable reverse proxy. The UI ships as an overlay panel rendered by Vue and persists
 its configuration via Tampermonkey storage (with a `localStorage` fallback for local development).
 
 ## Prerequisites
@@ -25,7 +25,7 @@ and close the settings panel via **Shift + P**.
 npm run test
 ```
 
-The Vitest suite covers the proxy URL 重写逻辑以及针对 `fetch`/`XMLHttpRequest` 包装器的行为。
+The Vitest suite covers the proxy URL 重写逻辑以及针对 `fetch`、`XMLHttpRequest`、`EventSource` 包装器的行为。
 
 端到端测试需要预先安装 Playwright 浏览器依赖：
 
@@ -39,7 +39,7 @@ npx playwright install
 npm run test:e2e
 ```
 
-该命令会先执行 `npm run build` 生成最新的 `.user.js`，再通过持久化的 Chromium 上下文加载构建产物。测试会在示例页面内触发 `fetch` 请求，验证默认情况下请求被重写到代理端点，以及添加绕过规则后请求恢复直连。
+该命令会先执行 `npm run build` 生成最新的 `.user.js`，再通过持久化的 Chromium 上下文加载构建产物。测试会在示例页面内触发 `fetch` 请求并模拟 `EventSource` 流，验证默认情况下请求被重写到代理端点，以及添加绕过规则后请求恢复直连。
 
 ## Building the userscript bundle
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "ai-proxy-redirector",
   "private": true,
   "version": "0.1.0",
-  "description": "Tampermonkey userscript bundle that rewrites fetch/XMLHttpRequest calls to a configurable reverse proxy.",
+  "description": "Tampermonkey userscript bundle that rewrites fetch/XMLHttpRequest/EventSource calls to a configurable reverse proxy.",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -122,8 +122,8 @@ onBeforeUnmount(() => {
         <header>
           <h1>Tampermonkey Proxy Settings</h1>
           <p>
-            All <code>fetch</code> and <code>XMLHttpRequest</code> calls will be rewritten to
-            <code>{{ previewUrl }}</code>.
+            All <code>fetch</code>, <code>XMLHttpRequest</code>, and <code>EventSource</code> traffic will be
+            rewritten to <code>{{ previewUrl }}</code>.
           </p>
         </header>
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -13,7 +13,7 @@ export default defineConfig({
         namespace: 'https://github.com/ai-proxy',
         version: '0.1.0',
         description:
-          'Intercepts fetch/XMLHttpRequest calls and rewrites them to a configurable reverse proxy endpoint.',
+          'Intercepts fetch/XMLHttpRequest/EventSource traffic and rewrites it to a configurable reverse proxy endpoint.',
         match: ['*://*/*'],
         grant: ['GM_getValue', 'GM_setValue', 'GM_registerMenuCommand'],
       },


### PR DESCRIPTION
## Summary
- add EventSource interception that reuses the proxy URL rewrite logic and keeps original constructor behaviour
- update the interceptor installer and vitest coverage to cover EventSource URL rewriting, bypasses, and close handling
- refresh UI copy and documentation to mention EventSource support across the project

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e5f7dcc7988320a5908061fbc5b03a