### PR TITLE
Add WebSocket support to reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This repository contains two coordinated pieces:
 - `frontend/` – a Vue-powered Tampermonkey userscript that rewrites every outbound `fetch`/`XMLHttpRequest`/`EventSource` call so
   it flows through a configurable proxy endpoint.
 - `server/` – a Node.js reverse proxy that accepts requests at `/protocol://host/...` and forwards them to the
-  original destination while preserving method, headers, body, and streaming responses.
+  original destination while preserving method, headers, body, and streaming responses. WebSocket upgrades use the same
+  format (`/ws://host/...` or `/wss://host/...`) and are forwarded to the upstream socket when the origin passes the
+  allow list.
 
 Follow the steps below for an end-to-end installation.
 
@@ -69,3 +71,13 @@ With the userscript enabled and the proxy server running:
 
 If requests fail, double-check that the proxy server is reachable from the browser and that the origin you are testing
 from is present in the server’s `ALLOWED_ORIGINS` list.
+
+To confirm WebSocket forwarding, open the browser console and try:
+
+```js
+const socket = new WebSocket('ws://localhost:8787/wss://echo.websocket.events')
+socket.addEventListener('open', () => socket.send('ping via proxy'))
+socket.addEventListener('message', (event) => console.log(event.data))
+```
+
+The connection should open and echo back messages when the proxy accepts the origin.

--- a/server/README.md
+++ b/server/README.md
@@ -40,3 +40,16 @@ that URL. Responses stream back to the client unchanged.
 
 For CORS preflight (`OPTIONS`) requests, the server automatically answers when the origin matches the
 `ALLOWED_ORIGINS` list.
+
+## WebSocket proxying
+
+The proxy also supports tunnelling WebSocket connections. Point your client at the proxy using the same path format,
+for example:
+
+```
+ws://localhost:8787/ws://echo.websocket.org/
+```
+
+The server validates the `Origin` header using the same allow list as HTTP requests. When the origin is not allowed,
+the upgrade request is rejected with `403 Forbidden`. Successful upgrades forward to the upstream `ws://`/`wss://`
+target using [`http-proxy`](https://www.npmjs.com/package/http-proxy)'s WebSocket support.

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,5 @@
+const http = require('http')
+
 const {
   HOST,
   PORT,
@@ -9,19 +11,66 @@ const {
   applyCors,
   createServer,
   createProxy,
+  isOriginAllowed,
 } = require('./lib/proxy')
 
+function writeSocketResponse(socket, statusCode, message) {
+  if (!socket || typeof socket.write !== 'function') {
+    return
+  }
+
+  const reason = http.STATUS_CODES[statusCode] || 'Error'
+  const body = message || reason
+  const payload =
+    `HTTP/1.1 ${statusCode} ${reason}\r\n` +
+    'Connection: close\r\n' +
+    'Content-Type: text/plain\r\n' +
+    `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+    '\r\n' +
+    body
+
+  try {
+    socket.write(payload)
+  } catch (error) {
+    // ignore write errors
+  } finally {
+    if (typeof socket.destroy === 'function') {
+      socket.destroy()
+    }
+  }
+}
+
 const proxy = createProxy({
+  changeOrigin: true,
+  ws: true,
   onError: (error, req, res) => {
     console.error('[proxy] Failed to forward request:', error.message)
-    if (!res.headersSent) {
-      res.writeHead(502, { 'Content-Type': 'text/plain' })
+    const message = 'Proxy error: ' + error.message
+
+    if (res && typeof res.writeHead === 'function') {
+      if (!res.headersSent) {
+        res.writeHead(502, { 'Content-Type': 'text/plain' })
+      }
+      res.end(message)
+      return
     }
-    res.end('Proxy error: ' + error.message)
+
+    if (res && typeof res.write === 'function') {
+      writeSocketResponse(res, 502, message)
+      return
+    }
+
+    if (req && req.socket && typeof req.socket.destroy === 'function') {
+      req.socket.destroy()
+    }
   },
 })
 
 const server = createServer((req, res) => {
+  if (req.headers.upgrade && req.headers.upgrade.toLowerCase() === 'websocket') {
+    return
+  }
+
   const target = parseTargetUrl(req.url)
 
   if (!target) {
@@ -35,6 +84,26 @@ const server = createServer((req, res) => {
   }
 
   proxy.web(req, res, { target })
+})
+
+server.on('upgrade', (req, socket, head) => {
+  const target = parseTargetUrl(req.url)
+
+  if (!target) {
+    writeSocketResponse(
+      socket,
+      400,
+      'Invalid proxy request. Use /https://example.com/path format.'
+    )
+    return
+  }
+
+  if (!isOriginAllowed(req.headers.origin)) {
+    writeSocketResponse(socket, 403, 'Origin not allowed')
+    return
+  }
+
+  proxy.ws(req, socket, head, { target })
 })
 
 server.listen(PORT, HOST, () => {


### PR DESCRIPTION
## Summary
- allow parsing of ws:// and wss:// targets and expose origin policy helper utilities
- handle HTTP upgrade requests with shared origin validation and forward them via http-proxy
- document WebSocket usage for the proxy server and userscript integration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5fab467a88320b4067dff6fe828b1